### PR TITLE
sets the total time

### DIFF
--- a/scripts/album.js
+++ b/scripts/album.js
@@ -211,7 +211,7 @@ var updatePlayerBarSong = function() {
   $('.currently-playing .artist-name').text(currentAlbum.artist);
   $('.currently-playing .artist-song-mobile').text(currentSongFromAlbum.title + " - " + currentAlbum.artist);
   $toggleButton.html(playerBarPauseButton);
-  setTotalTimeInPlayerBar(currentSoundFile); 
+  setTotalTimeInPlayerBar(currentSongFromAlbum.duration);
 };
 
 var playButtonTemplate = '<a class="album-song-button"><span class="ion-play"></span></a>';


### PR DESCRIPTION
So setting the total time is as easy as using the [currentSongFromAlbum](https://github.com/bdougie/bloc-jams-sage/blob/assn-21-seek/scripts/album.js#L12).

```js
// example a currentSongFromAlbum
{title: "Blue", duration: 161.71, audioUrl: "assets/music/blue"}
```

My change is to call the duration from there.